### PR TITLE
Bug Fixes and Organization

### DIFF
--- a/CircularNeuralNetwork.sln
+++ b/CircularNeuralNetwork.sln
@@ -13,10 +13,10 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{A8FA42D0-A44B-4EAE-B138-3AD4ACA67C81}.Debug|x64.ActiveCfg = Debug|Win32
-		{A8FA42D0-A44B-4EAE-B138-3AD4ACA67C81}.Debug|x64.Build.0 = Debug|Win32
-		{A8FA42D0-A44B-4EAE-B138-3AD4ACA67C81}.Debug|x86.ActiveCfg = Release|Win32
-		{A8FA42D0-A44B-4EAE-B138-3AD4ACA67C81}.Debug|x86.Build.0 = Release|Win32
+		{A8FA42D0-A44B-4EAE-B138-3AD4ACA67C81}.Debug|x64.ActiveCfg = Debug|x64
+		{A8FA42D0-A44B-4EAE-B138-3AD4ACA67C81}.Debug|x64.Build.0 = Debug|x64
+		{A8FA42D0-A44B-4EAE-B138-3AD4ACA67C81}.Debug|x86.ActiveCfg = Debug|Win32
+		{A8FA42D0-A44B-4EAE-B138-3AD4ACA67C81}.Debug|x86.Build.0 = Debug|Win32
 		{A8FA42D0-A44B-4EAE-B138-3AD4ACA67C81}.Release|x64.ActiveCfg = Release|x64
 		{A8FA42D0-A44B-4EAE-B138-3AD4ACA67C81}.Release|x64.Build.0 = Release|x64
 		{A8FA42D0-A44B-4EAE-B138-3AD4ACA67C81}.Release|x86.ActiveCfg = Release|Win32

--- a/CircularNeuralNetwork/CircularNeuralNetwork.vcxproj
+++ b/CircularNeuralNetwork/CircularNeuralNetwork.vcxproj
@@ -75,15 +75,19 @@
     <LinkIncremental>true</LinkIncremental>
     <PreBuildEventUseInBuild>false</PreBuildEventUseInBuild>
     <PreLinkEventUseInBuild>false</PreLinkEventUseInBuild>
+    <TargetName>$(ProjectName)_$(PlatformShortName)</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
+    <TargetName>$(ProjectName)_$(PlatformShortName)</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
+    <TargetName>$(ProjectName)_$(PlatformShortName)</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
+    <TargetName>$(ProjectName)_$(PlatformShortName)</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -100,7 +104,8 @@
       <EnableUAC>false</EnableUAC>
     </Link>
     <PostBuildEvent>
-      <Command>for /f "usebackq delims=" %%I in (`dir /b/s "$(USERPROFILE)\source\repos\*$(TargetFileName)"`) do if not "$(TargetPath)"=="C:%%~pI$(TargetFileName)" (copy "$(TargetPath)" "%%~pI" &amp; echo Dll updated in C:%%~pI)</Command>
+      <Command>
+      </Command>
       <Message>Copying dll file to local projects</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -147,7 +152,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;CIRCULARNEURALNETWORKDLL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;CIRCULARNEURALNETWORK_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>

--- a/CircularNeuralNetwork/InputNode.cpp
+++ b/CircularNeuralNetwork/InputNode.cpp
@@ -11,6 +11,10 @@ Network::InputNode::InputNode() :
 	weights(vector<float>())
 {}
 
+Network::InputNode::~InputNode() {
+	weights.~vector<float>();
+}
+
 Network::InputNode::InputNode(float _current_value, vector<float> _weights) :
 	current_value(_current_value),
 	weights(_weights)

--- a/CircularNeuralNetwork/MiddleNode.cpp
+++ b/CircularNeuralNetwork/MiddleNode.cpp
@@ -13,6 +13,11 @@ Network::MiddleNode::MiddleNode() :
 	bias(0)
 {}
 
+Network::MiddleNode::~MiddleNode() {
+	inputs.~vector<float>();
+	weights.~vector<float>();
+}
+
 Network::MiddleNode::MiddleNode(float _current_value, vector<float> _weights, float _bias) :
 	current_value(_current_value),
 	inputs(vector<float>()),

--- a/CircularNeuralNetwork/Network.h
+++ b/CircularNeuralNetwork/Network.h
@@ -12,6 +12,8 @@ class Network {
 
 		InputNode();
 
+		~InputNode();
+
 		InputNode(float _current_value, std::vector<float> _weights);
 
 		void setCurrentValue(float new_value);
@@ -31,6 +33,8 @@ class Network {
 		float bias;
 
 		MiddleNode();
+
+		~MiddleNode();
 
 		MiddleNode(float _current_value, std::vector<float> _weights, float _bias);
 
@@ -53,6 +57,8 @@ class Network {
 		
 		OutputNode();
 
+		~OutputNode();
+
 		OutputNode(float _current_value, float _bias);
 
 		void calcCurrentValue();
@@ -74,9 +80,12 @@ class Network {
 	std::vector<float> outputs;
 	bool thinking;
 	Network(std::vector<InputNode> _input_nodes, std::vector<MiddleNode> _middle_nodes, std::vector<OutputNode> _output_nodes);
+	void stepBase();
 
 public:
 	NETWORK_API Network();
+
+	NETWORK_API ~Network();
 
 	NETWORK_API static Network createRandom(unsigned int input_node_count, unsigned int middle_node_count, unsigned int output_node_count);
 
@@ -110,7 +119,7 @@ public:
 
 	NETWORK_API float getOutputAt(int index);
 
-	NETWORK_API void sendInputs(std::vector<float> inputs);
+	NETWORK_API void sendInputs(float inputs[]);
 
 	NETWORK_API void mutate(float scale);
 };

--- a/CircularNeuralNetwork/OutputNode.cpp
+++ b/CircularNeuralNetwork/OutputNode.cpp
@@ -12,6 +12,10 @@ Network::OutputNode::OutputNode() :
 	bias(0)
 {}
 
+Network::OutputNode::~OutputNode() {
+	inputs.~vector<float>();
+}
+
 Network::OutputNode::OutputNode(float _current_value, float _bias) :
 	current_value(_current_value),
 	inputs(vector<float>()),


### PR DESCRIPTION
### Fixed an issue caused by using STL in the user interface
- `sendInputs()` now requires an array instead of a vector

### Refactored to allow for use in both x64 and Win32
- setup.h and CNeuralNet.h added to help with using the proper lib file
- lib and dll files are now named with their respective platform compatibility

### Fixed issue caused by not properly freeing memory when objects are deconstructed
- added deconstructors to Network, InputNode, MiddleNode, and OutputNode to properly dump their vectors

### Fixed issue caused by #2 (oops) which caused `step()` to not function properly
- added `baseStep()` to allow `beginThinking()` to freely execute steps, while `step()` must ensure the network is not already thinking

### Fixed issue where network outputs would remain static without new inputs in a small network
- input nodes no longer get set to 0 after sending outputs