### PR TITLE
Several various optimizations

### DIFF
--- a/CircularNeuralNetwork/InputNode.cpp
+++ b/CircularNeuralNetwork/InputNode.cpp
@@ -1,10 +1,7 @@
 #include "pch.h"
-#include <mutex>
 #include "Network.h"
 
 using namespace std;
-
-mutex input_node_thread_lock;
 
 Network::InputNode::InputNode() :
 	current_value(0),
@@ -15,7 +12,7 @@ Network::InputNode::~InputNode() {
 	weights.~vector<float>();
 }
 
-Network::InputNode::InputNode(float _current_value, vector<float> _weights) :
+Network::InputNode::InputNode(float _current_value, const vector<float>& _weights) :
 	current_value(_current_value),
 	weights(_weights)
 {}
@@ -31,51 +28,27 @@ ostream& operator<<(ostream& out_stream, const Network::InputNode& node) {
 }
 
 istream& operator>>(istream& in_stream, Network::InputNode& node) {
-	Network::InputNode newNode;
-	in_stream >> newNode.current_value;
+	in_stream >> node.current_value;
 	unsigned int weights_size;
 	in_stream >> weights_size;
 	for (unsigned int i = 0; i < weights_size; i++) {
 		float weight;
 		in_stream >> weight;
-		newNode.weights.push_back(weight);
+		node.weights.push_back(weight);
 	}
-	input_node_thread_lock.lock();
-	node = newNode;
-	input_node_thread_lock.unlock();
 	return in_stream;
 }
 
-void Network::InputNode::setCurrentValue(float new_value) {
-	input_node_thread_lock.lock();
-	current_value = sigmoid(new_value);
-	input_node_thread_lock.unlock();
-}
-
 void Network::InputNode::randomize() {
-	input_node_thread_lock.lock();
 	current_value = random(-1, 1);
-	input_node_thread_lock.unlock();
 	unsigned int const weights_size = (unsigned int)weights.size();
 	for (unsigned int i = 0; i < weights_size; i++) {
-		input_node_thread_lock.lock();
 		weights.at(i) = random(-1, 1);
-		input_node_thread_lock.unlock();
 	}
-}
-
-float Network::InputNode::getWeightAt(int index) {
-	return weights.at(index);
-}
-
-float Network::InputNode::getCurrentValue() {
-	return current_value;
 }
 
 void Network::InputNode::mutate(float scale) {
 	for (float& weight : weights) {
-		input_node_thread_lock.lock();
 		weight = clamp(weight + random(-scale, scale), -1, 1);
-		input_node_thread_lock.unlock();
 	}
 }

--- a/CircularNeuralNetwork/MiddleNode.cpp
+++ b/CircularNeuralNetwork/MiddleNode.cpp
@@ -1,28 +1,24 @@
 #include "pch.h"
-#include <mutex>
 #include "Network.h"
 
 using namespace std;
 
-mutex middle_node_thread_lock;
-
 Network::MiddleNode::MiddleNode() :
 	current_value(0),
-	inputs(vector<float>()),
 	weights(vector<float>()),
-	bias(0)
+	bias(0),
+	inputSum(0)
 {}
 
 Network::MiddleNode::~MiddleNode() {
-	inputs.~vector<float>();
 	weights.~vector<float>();
 }
 
-Network::MiddleNode::MiddleNode(float _current_value, vector<float> _weights, float _bias) :
+Network::MiddleNode::MiddleNode(float _current_value, const vector<float>& _weights, float _bias) :
 	current_value(_current_value),
-	inputs(vector<float>()),
 	weights(_weights),
-	bias(_bias)
+	bias(_bias),
+	inputSum(_bias)
 {}
 
 ostream& operator<<(ostream& out_stream, const Network::MiddleNode& node) {
@@ -35,70 +31,32 @@ ostream& operator<<(ostream& out_stream, const Network::MiddleNode& node) {
 }
 
 istream& operator>>(istream& in_stream, Network::MiddleNode& node) {
-	Network::MiddleNode newNode;
-	in_stream >> newNode.current_value;
+	in_stream >> node.current_value;
 	unsigned int weights_size;
 	in_stream >> weights_size;
 	for (unsigned int i = 0; i < weights_size; i++) {
 		float weight;
 		in_stream >> weight;
-		newNode.weights.push_back(weight);
+		node.weights.push_back(weight);
 	}
-	in_stream >> newNode.bias;
-	middle_node_thread_lock.lock();
-	node = newNode;
-	middle_node_thread_lock.unlock();
+	in_stream >> node.bias;
 	return in_stream;
 }
 
-void Network::MiddleNode::calcCurrentValue() {
-	float sum = bias;
-	for (float input : inputs) {
-		sum += input;
-	}
-	middle_node_thread_lock.lock();
-	current_value = sigmoid(sum);
-	inputs.clear();
-	middle_node_thread_lock.unlock();
-}
-
 void Network::MiddleNode::randomize() {
-	middle_node_thread_lock.lock();
 	current_value = random(-1, 1);
-	inputs = vector<float>();
-	middle_node_thread_lock.unlock();
 	unsigned int weights_size = (unsigned int)weights.size();
 	for (unsigned int i = 0; i < weights_size; i++) {
-		middle_node_thread_lock.lock();
 		weights.at(i) = random(-1, 1);
-		middle_node_thread_lock.unlock();
 	}
-	middle_node_thread_lock.lock();
 	bias = random(-1, 1);
-	middle_node_thread_lock.unlock();
-}
-
-void Network::MiddleNode::addInput(float input) {
-	middle_node_thread_lock.lock();
-	inputs.push_back(input);
-	middle_node_thread_lock.unlock();
-}
-
-float Network::MiddleNode::getWeightAt(int index) {
-	return weights.at(index);
-}
-
-float Network::MiddleNode::getCurrentValue() {
-	return current_value;
+	inputSum = bias;
 }
 
 void Network::MiddleNode::mutate(float scale) {
 	for (float& weight : weights) {
-		middle_node_thread_lock.lock();
 		weight = clamp(weight + random(-scale, scale), -1, 1);
-		middle_node_thread_lock.unlock();
 	}
-	middle_node_thread_lock.lock();
 	bias = clamp(bias + random(-1, 1), -1, 1);
-	middle_node_thread_lock.unlock();
+	inputSum = bias;
 }

--- a/CircularNeuralNetwork/Network.h
+++ b/CircularNeuralNetwork/Network.h
@@ -14,60 +14,38 @@ class Network {
 
 		~InputNode();
 
-		InputNode(float _current_value, std::vector<float> _weights);
-
-		void setCurrentValue(float new_value);
+		InputNode(float _current_value, const std::vector<float>& _weights);
 
 		void randomize();
-
-		float getWeightAt(int index);
-
-		float getCurrentValue();
 
 		void mutate(float scale);
 	};
 	struct MiddleNode {
 		float current_value;
-		std::vector<float> inputs;
 		std::vector<float> weights;
 		float bias;
+		float inputSum;
 
 		MiddleNode();
 
 		~MiddleNode();
 
-		MiddleNode(float _current_value, std::vector<float> _weights, float _bias);
-
-		void calcCurrentValue();
+		MiddleNode(float _current_value, const std::vector<float>& _weights, float _bias);
 
 		void randomize();
-
-		void addInput(float input);
-
-		float getWeightAt(int index);
-
-		float getCurrentValue();
 
 		void mutate(float scale);
 	};
 	struct OutputNode {
 		float current_value;
-		std::vector<float> inputs;
 		float bias;
+		float inputSum;
 		
 		OutputNode();
 
-		~OutputNode();
-
 		OutputNode(float _current_value, float _bias);
 
-		void calcCurrentValue();
-
 		void randomize();
-
-		void addInput(float input);
-
-		float getCurrentValue();
 
 		void mutate(float scale);
 	};
@@ -79,8 +57,8 @@ class Network {
 	unsigned int output_nodes_size;
 	std::vector<float> outputs;
 	bool thinking;
-	Network(std::vector<InputNode> _input_nodes, std::vector<MiddleNode> _middle_nodes, std::vector<OutputNode> _output_nodes);
-	void stepBase();
+	Network(const std::vector<InputNode>& _input_nodes, const std::vector<MiddleNode>& _middle_nodes, const std::vector<OutputNode>& _output_nodes);
+	void threadedStep();
 
 public:
 	NETWORK_API Network();
@@ -107,21 +85,21 @@ public:
 
 	friend std::istream& operator>>(std::istream& in_stream, Network& net);
 
-	NETWORK_API void save(const char* filename);
+	NETWORK_API bool save(const char* filename);
 
 	NETWORK_API static bool load(const char* filename, Network& net);
 
-	NETWORK_API void randomize();
+	NETWORK_API bool randomize();
 
-	NETWORK_API void step();
+	NETWORK_API bool step();
 
 	NETWORK_API void beginThinking();
 
 	NETWORK_API void endThinking();
 
-	NETWORK_API float getOutputAt(int index);
+	NETWORK_API float* getOutputs();
 
-	NETWORK_API void sendInputs(float inputs[]);
+	NETWORK_API void sendInputs(const float inputs[]);
 
-	NETWORK_API void mutate(float scale);
+	NETWORK_API bool mutate(float scale);
 };


### PR DESCRIPTION
-Removed unnecessary thread locking
-Network now handles all thread locking operations
-Changed the way nodes accept inputs
-Changed several function parameters to references instead of objects
-Removed unnecessary getters and setters
-Network can now only accept inputs and send outputs while thinking - all other functions will return `false` while the Network is thinking
-Changed `getOutputsAt()` to `getOutputs()`
-Refactored the step function to spend less time in thread lock while the Network is thinking