### PR TITLE
Reduced mutex locking

### DIFF
--- a/CircularNeuralNetwork/InputNode.cpp
+++ b/CircularNeuralNetwork/InputNode.cpp
@@ -1,5 +1,4 @@
 #include "pch.h"
-#include "Network.h"
 
 using namespace std;
 

--- a/CircularNeuralNetwork/MiddleNode.cpp
+++ b/CircularNeuralNetwork/MiddleNode.cpp
@@ -1,5 +1,4 @@
 #include "pch.h"
-#include "Network.h"
 
 using namespace std;
 

--- a/CircularNeuralNetwork/Network.cpp
+++ b/CircularNeuralNetwork/Network.cpp
@@ -1,11 +1,10 @@
 #include "pch.h"
 #include <fstream>
 #include <mutex>
-#include "Network.h"
 
 using namespace std;
 
-mutex network_thread_lock;
+mutex mutex_lock;
 
 Network::Network() :
 	input_nodes(vector<InputNode>()),
@@ -19,13 +18,13 @@ Network::Network() :
 {}
 
 Network::Network(unsigned int input_node_count, unsigned int middle_node_count, unsigned int output_node_count) :
-	input_nodes(vector<InputNode>(input_node_count, InputNode(0, vector<float>(middle_node_count, 0)))),
+	input_nodes(vector<InputNode>(input_node_count, InputNode(0, vector<float>(middle_node_count)))),
 	middle_nodes(vector<MiddleNode>(middle_node_count, MiddleNode(0, vector<float>(middle_node_count + output_node_count - 1), 0))),
-	output_nodes(vector<OutputNode>(output_node_count, OutputNode(0, 0))),
+	output_nodes(vector<OutputNode>(output_node_count)),
 	input_nodes_size(input_node_count),
 	middle_nodes_size(middle_node_count),
 	output_nodes_size(output_node_count),
-	outputs(vector<float>(output_node_count, 0)),
+	outputs(vector<float>(output_node_count)),
 	thinking(false)
 {}
 
@@ -43,37 +42,36 @@ Network::Network(const vector<InputNode>& _input_nodes, const vector<MiddleNode>
 	input_nodes_size((unsigned int)_input_nodes.size()),
 	middle_nodes_size((unsigned int)_middle_nodes.size()),
 	output_nodes_size((unsigned int)_output_nodes.size()),
-	outputs(vector<float>()),
+	outputs(vector<float>(_output_nodes.size())),
 	thinking(false)
-{
-	for (OutputNode& output_node : output_nodes) {
-		outputs.push_back(output_node.current_value);
-	}
-}
+{}
 
 Network Network::createRandom(unsigned int input_node_count, unsigned int middle_node_count, unsigned int output_node_count) {
 	vector<InputNode> random_input_nodes;
+	random_input_nodes.reserve(input_node_count);
 	for (unsigned int input_node_index = 0; input_node_index < input_node_count; input_node_index++) {
-		vector<float> input_weights;
+		vector<float> input_weights(middle_node_count);
 		for (unsigned int weight_index = 0; weight_index < middle_node_count; weight_index++) {
-			input_weights.push_back(random(-1, 1));
+			input_weights.at(weight_index) = random(-1, 1);
 		}
 
 		random_input_nodes.push_back(InputNode(random(-1, 1), input_weights));
 	}
 
 	vector<MiddleNode> random_middle_nodes;
+	random_middle_nodes.reserve(middle_node_count);
 	for (unsigned int middle_node_index = 0; middle_node_index < middle_node_count; middle_node_index++) {
-		vector<float> middle_weights;
 		unsigned int weight_count = middle_node_count + output_node_count - 1;
+		vector<float> middle_weights(weight_count);
 		for (unsigned int weight_index = 0; weight_index < weight_count; weight_index++) {
-			middle_weights.push_back(random(-1, 1));
+			middle_weights.at(weight_index) = random(-1, 1);
 		}
 
 		random_middle_nodes.push_back(MiddleNode(random(-1, 1), middle_weights, random(-1, 1)));
 	}
 
 	vector<OutputNode> random_output_nodes;
+	random_output_nodes.reserve(output_node_count);
 	for (unsigned int output_node_index = 0; output_node_index < output_node_count; output_node_index++) {
 		random_output_nodes.push_back(OutputNode(random(-1, 1), random(-1, 1)));
 	}
@@ -93,10 +91,6 @@ ostream& operator<<(ostream& out_stream, const Network& net){
 	out_stream << net.output_nodes_size << endl;
 	for (const Network::OutputNode& output_node : net.output_nodes) {
 		out_stream << output_node << endl;
-	}
-	unsigned int outputs_size = (unsigned int)net.outputs.size();
-	for (unsigned int i = 0; i < outputs_size - 1; i++) {
-		out_stream << net.outputs.at(i) << endl;
 	}
 	return out_stream;
 }
@@ -119,9 +113,6 @@ istream& operator>>(istream& in_stream, Network& net) {
 		Network::OutputNode output_node;
 		in_stream >> output_node;
 		net.output_nodes.push_back(output_node);
-	}
-	for (Network::OutputNode& output_node : net.output_nodes) {
-		net.outputs.push_back(output_node.current_value);
 	}
 	return in_stream;
 }
@@ -160,76 +151,8 @@ bool Network::randomize() {
 	return true;
 }
 
-void Network::threadedStep() {
-	// input nodes send outputs
-	for (InputNode& input_node : input_nodes) {
-		for (unsigned int middle_node_index = 0; middle_node_index < middle_nodes_size; middle_node_index++) {
-			float& middleInputSum = middle_nodes.at(middle_node_index).inputSum;
-			float input = middleInputSum + (input_node.current_value * input_node.weights.at(middle_node_index));
-			network_thread_lock.lock();
-			middleInputSum = input;
-			network_thread_lock.unlock();
-		}
-	}
-
-	// middle nodes send outputs
-	for (unsigned int sender_index = 0; sender_index < middle_nodes_size; sender_index++) {
-		bool sender_reached = false;
-		MiddleNode sender = middle_nodes.at(sender_index);
-		for (unsigned int middle_node_index = 0; middle_node_index < middle_nodes_size; middle_node_index++) {
-			if (sender_index != middle_node_index) {
-				float& middleInputSum = middle_nodes.at(middle_node_index).inputSum;
-				float input = middleInputSum + (sender.current_value * sender.weights.at(middle_node_index - sender_reached));
-				network_thread_lock.lock();
-				middleInputSum = input;
-				network_thread_lock.unlock();
-			}
-			else {
-				sender_reached = true;
-			}
-		}
-		for (unsigned int output_node_index = 0; output_node_index < output_nodes_size; output_node_index++) {
-			float& outputInputSum = output_nodes.at(output_node_index).inputSum;
-			float input = outputInputSum + (sender.current_value * sender.weights.at(output_node_index + middle_nodes_size - 1));
-			network_thread_lock.lock();
-			outputInputSum = input;
-			network_thread_lock.unlock();
-		}
-	}
-
-	// middle nodes calculate current value
-	for (MiddleNode& middle_node : middle_nodes) {
-		float value = sigmoid(middle_node.inputSum);
-		network_thread_lock.lock();
-		middle_node.current_value = value;
-		middle_node.inputSum = middle_node.bias;
-		network_thread_lock.unlock();
-	}
-
-	// output nodes calculate current value
-	for (OutputNode& output_node : output_nodes) {
-		float value = sigmoid(output_node.inputSum);
-		network_thread_lock.lock();
-		output_node.current_value = value;
-		output_node.inputSum = output_node.bias;
-		network_thread_lock.unlock();
-	}
-
-	// replace elements of outputs using output_nodes
-	for (unsigned int output_index = 0; output_index < output_nodes_size; output_index++) {
-		float& outputValue = outputs.at(output_index);
-		float outputNodeValue = output_nodes.at(output_index).current_value;
-		network_thread_lock.lock();
-		outputValue = outputNodeValue;
-		network_thread_lock.unlock();
-	}
-}
-
-bool Network::step() {
-	// stepBase() should not be called while the network is already thinking
-	if (thinking) {
-		return false;
-	}
+void Network::baseStep() {
+	mutex_lock.lock();
 
 	// input nodes send outputs
 	for (InputNode& input_node : input_nodes) {
@@ -266,41 +189,49 @@ bool Network::step() {
 		output_node.current_value = sigmoid(output_node.inputSum);
 		output_node.inputSum = output_node.bias;
 	}
+	mutex_lock.unlock();
+}
 
-	// replace elements of outputs using output_nodes
-	for (unsigned int output_index = 0; output_index < output_nodes_size; output_index++) {
-		outputs.at(output_index) = output_nodes.at(output_index).current_value;
+bool Network::step() {
+	if (thinking) {
+		return false;
+	}
+	baseStep();
+	return true;
+}
+
+bool Network::beginThinking() {
+	if (thinking) {
+		return false;
+	}
+	thinking = true;
+	while (thinking) {
+		baseStep();
 	}
 	return true;
 }
 
-void Network::beginThinking() {
-	network_thread_lock.lock();
-	thinking = true;
-	network_thread_lock.unlock();
-	while (thinking) {
-		threadedStep();
-	}
-}
-
 void Network::endThinking() {
-	network_thread_lock.lock();
+	mutex_lock.lock();
 	thinking = false;
-	network_thread_lock.unlock();
+	mutex_lock.unlock();
 }
 
 float* Network::getOutputs() {
+	mutex_lock.lock();
+	for (unsigned int i = 0; i < output_nodes_size; i++) {
+		outputs.at(i) = output_nodes.at(i).current_value;
+	}
+	mutex_lock.unlock();
 	return outputs.data();
 }
 
 void Network::sendInputs(const float inputs[]) {
+	mutex_lock.lock();
 	for (unsigned int i = 0; i < input_nodes_size; i++) {
-		float& inputCurrentValue = input_nodes.at(i).current_value;
-		float newCurrentValue = sigmoid(inputs[i]);
-		network_thread_lock.lock();
-		inputCurrentValue = newCurrentValue;
-		network_thread_lock.unlock();
+		input_nodes.at(i).current_value = sigmoid(inputs[i]);
 	}
+	mutex_lock.unlock();
 }
 
 bool Network::mutate(float scale) {

--- a/CircularNeuralNetwork/Network.h
+++ b/CircularNeuralNetwork/Network.h
@@ -58,7 +58,7 @@ class Network {
 	std::vector<float> outputs;
 	bool thinking;
 	Network(const std::vector<InputNode>& _input_nodes, const std::vector<MiddleNode>& _middle_nodes, const std::vector<OutputNode>& _output_nodes);
-	void threadedStep();
+	void baseStep();
 
 public:
 	NETWORK_API Network();
@@ -93,7 +93,7 @@ public:
 
 	NETWORK_API bool step();
 
-	NETWORK_API void beginThinking();
+	NETWORK_API bool beginThinking();
 
 	NETWORK_API void endThinking();
 

--- a/CircularNeuralNetwork/OutputNode.cpp
+++ b/CircularNeuralNetwork/OutputNode.cpp
@@ -1,5 +1,4 @@
 #include "pch.h"
-#include "Network.h"
 
 using namespace std;
 


### PR DESCRIPTION
-Removed unnecessary includes
-Vectors reserve memory properly when applicable
-Output array accumulates when `getOutputs()` is called rather than after every step
-Output array is no longer read or written to files
-Mutex is locked during `step()`, `sendInputs()`, and `getOutputs()`
-`beginThinking()` now returns a bool depending on if the Network is already running